### PR TITLE
Remove unnecessary sync from Blog model

### DIFF
--- a/models/blog.js
+++ b/models/blog.js
@@ -32,7 +32,4 @@ Blog.init({
   modelName: 'blog'
 })
 
-// Create table if not exists executed at start of app
-Blog.sync()
-
 module.exports = Blog


### PR DESCRIPTION
Models are now sync'd in `database.js` this was an artefact from previous implementation.

Removed and tested with `npm run test`.