### PR TITLE
5.17-5.23

### DIFF
--- a/app.js
+++ b/app.js
@@ -17,6 +17,11 @@ app.use('/api/blogs', blogsRouter)
 app.use('/api/users', usersRouter)
 app.use('/api/login', loginRouter)
 
+if (process.env.NODE_ENV === 'test') {
+  const testsRouter = require('./controllers/tests')
+  app.use('/api/tests', testsRouter)
+}
+
 app.use(middleware.unknownEndpoint)
 app.use(middleware.errorHandler)
 

--- a/controllers/tests.js
+++ b/controllers/tests.js
@@ -1,0 +1,15 @@
+const config = require('../utils/config')
+const testsRouter = require('express').Router()
+const Blog = require('../models/blog')
+const User = require('../models/user')
+
+// For use with Cypress E2E tests.
+// Allow a post request to reset models in db.
+testsRouter.post('/reset', async (req, res) => {
+  await Blog.sync({force: true})
+  await User.sync({force: true})
+
+  res.status(204).end()
+})
+
+module.exports = testsRouter

--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
     "dev": "cross-env NODE_ENV=development nodemon index.js",
     "test": "cross-env NODE_ENV=test jest --verbose --runInBand --detectOpenHandles",
     "lint": "eslint .",
-    "fix-lint": "eslint . --fix"
+    "lint:fix": "eslint . --fix",
+    "start:test": "cross-env NODE_ENV=test node index.js"
   },
   "author": "James McNeilis",
   "license": "MIT",


### PR DESCRIPTION
Small extension for https://fullstackopen.com/en/part5/end_to_end_testing

Adds a test route, which is only loaded when `NODE_ENV=test` and allows a complete drop of tables in db.